### PR TITLE
fixed typo and python example

### DIFF
--- a/20241112_pm.md
+++ b/20241112_pm.md
@@ -59,7 +59,7 @@ UOp(Ops.SINK, dtypes.void, arg=KernelInfo(local_dims=0, upcasted=0, dont_use_loc
 ```
 
 You should be able to map some parts of it to the generated code. For example,
-`Oops.STORE` with src of `DEFINE_GLOBAL` maps to `data0[`, the `dtypes.float.ptr`
+`Ops.STORE` with src of `DEFINE_GLOBAL` maps to `data0[`, the `dtypes.float.ptr`
 results in the pointer dereferencing (`*`), since it is part of the src of a STORE
 operation, an equal sign (`=`) should follow, after which we should do code generation
 for its siblings, which would be the right hand side. The right hand side is 
@@ -111,9 +111,9 @@ uh, patterns and writer functions:
 
 ```python
 patterns = [
-  (STORE, ), lambda uop: "=",
-  (CONST, ), lambda uop: f" {uop.arg} ",
-  (ADD, ), lambda uop: f" + ",
+  (STORE, lambda uop: "="),
+  (CONST, lambda uop: f" {uop.arg} "),
+  (ADD, lambda uop: f" + "),
 ]
 ```
 

--- a/20241112_pm.md
+++ b/20241112_pm.md
@@ -161,7 +161,7 @@ uop
 You can write the following to match it:
 
 ```python
-UPat(Ops.STORE, name="x", src=(UPat.var("define_global"), UPat.var("addition"))), lambda x, define_global, addition: ...
+UPat(Ops.STORE, name="x", src=(UPat.var("define_global"), UPat.var("addition")), lambda x, define_global, addition: ... )
 ```
 
 The uop for `STORE` will be passed to lambda in the argument specified by `name`, 


### PR DESCRIPTION
the old python would give "index out of range" error for pattern[1]