### PR TITLE
Fixed typo in 20241231_intro.md

### DIFF
--- a/20241231_intro.md
+++ b/20241231_intro.md
@@ -138,7 +138,7 @@ print((a.sum(0).tolist()))
 
 ## Understanding the Intermediate Representation
 
-Like any other compiler, tinygrad uses an Artifical Syntax Tree to represent the computation before generating the
+Like any other compiler, tinygrad uses an Abstract Syntax Tree to represent the computation before generating the
 code. It is called `UOp`:
 
 ```python


### PR DESCRIPTION
Changed "Artifical Syntax Tree" to "Abstract Syntax Tree".