### PR TITLE
fix typo

### DIFF
--- a/20241231_intro.md
+++ b/20241231_intro.md
@@ -242,7 +242,7 @@ two constants is "folded" before the render stage, so you get the value 2, inste
 optimization techniques. Let's see another example that renders the thread position:
 
 ```python
-MetalRenderer().render([
+MetalRenderer().render("example", [
   UOp(Ops.SPECIAL, dtypes.int, arg=("gidx0", 16))
 ])
 ```


### PR DESCRIPTION
Before this change, running the script led to
```
TypeError: CStyleLanguage.render() missing 1 required positional argument: 'uops'
```