### PR TITLE
changed long to double

### DIFF
--- a/20241231_intro.md
+++ b/20241231_intro.md
@@ -41,7 +41,7 @@ There are four main rows in the output. The first two ("empty") refers to the va
 input to the addition. Their data is populated with zeros, and is designated with "empty". Under the hood, this uses
 the default memory allocation method for the GPU device. If we want to put actual data in it, there would be a "transfer"
 method (not covered yet). The number 16 refers to the fact we allocated 16 elements, each of which is of dtype "float".
-"float" is a shorthand for "float32", occupying 4 bytes, or 32 bits (similarly, "long" is a shorthand for float64, occupying
+"float" is a shorthand for "float32", occupying 4 bytes, or 32 bits (similarly, "double" is a shorthand for float64, occupying
 64 bits, or 8 bytes). We see that the next part says 0.00GB, it's just rounded down to zero, because our example is too small.
 
 The third row designate the computation. "E" is short for "elementwise", meaning the input and output have the same shape


### PR DESCRIPTION
alias to float64 in notes is "long". Per tinygrad.dtypes, should be "double" 