### PR TITLE
Fix url render on gh pages markdown

### DIFF
--- a/20241217_st.md
+++ b/20241217_st.md
@@ -29,7 +29,7 @@ These two values actually are the input to the shapetracker implementation:
 View.create(shape=(2, 2), strides=(2, 1))
 ```
 
-Here's a tool for visualization: https://mesozoic-egg.github.io/shape-stride-visualizer/#/shape-stride
+Here's a tool for visualization: [https://mesozoic-egg.github.io/shape-stride-visualizer/#/shape-stride](https://mesozoic-egg.github.io/shape-stride-visualizer/#/shape-stride)
 
 <img src="images/img68.png">
 


### PR DESCRIPTION
<img width="966" alt="Screenshot 2025-02-26 at 10 58 56 AM" src="https://github.com/user-attachments/assets/470be571-f9d9-4438-955a-971f0f48c2d9" />

The url is clickable on the repo but not on github pages